### PR TITLE
 refactor: 서비스 레이어 책임 분리 및 클린코드 적용

### DIFF
--- a/src/main/java/com/site/xidong/config/AwsV2Config.java
+++ b/src/main/java/com/site/xidong/config/AwsV2Config.java
@@ -1,0 +1,32 @@
+package com.site.xidong.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.transcribe.TranscribeClient;
+
+@Configuration
+public class AwsV2Config {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+
+    @Bean
+    public TranscribeClient transcribeClient() {
+        return TranscribeClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/com/site/xidong/domain/feedback/service/AwsTranscribe.java
+++ b/src/main/java/com/site/xidong/domain/feedback/service/AwsTranscribe.java
@@ -2,13 +2,14 @@ package com.site.xidong.domain.feedback.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.NoArgsConstructor;
+import com.site.xidong.global.exception.CustomException;
+import com.site.xidong.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.transcribe.TranscribeClient;
@@ -16,176 +17,148 @@ import software.amazon.awssdk.services.transcribe.model.*;
 
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
-@NoArgsConstructor
+@RequiredArgsConstructor
 public class AwsTranscribe {
-    // AWS 설정
-    private static final Region REGION = Region.AP_NORTHEAST_2; // 서울 리전
-    private static final String BUCKET_NAME = "dive-s3-ver2"; // S3 버킷명
 
-    // S3에 오디오 파일 업로드
-    public static String uploadToS3(AwsCredentialsProvider credentialsProvider, byte[] videoBytes) {
+    private static final int POLLING_INTERVAL_MS = 5_000;
+    private static final int MAX_POLLING_ATTEMPTS = 120; // 최대 10분 (5초 × 120)
+
+    private final S3Client s3Client;
+    private final TranscribeClient transcribeClient;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadToS3(byte[] videoBytes) {
+        log.info("uploadToS3 시작 - videoBytes 크기: {}", videoBytes.length);
+
+        ProcessBuilder pb = new ProcessBuilder(
+                "ffmpeg",
+                "-i", "pipe:0",
+                "-vn",
+                "-acodec", "libmp3lame",
+                "-ar", "44100",
+                "-ac", "2",
+                "-f", "mp3",
+                "pipe:1"
+        );
+        pb.redirectErrorStream(false);
+        Process process;
         try {
-            log.info("uploadToS3 시작 - videoBytes 크기: {}", videoBytes.length);
+            process = pb.start();
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.STT_FAILED);
+        }
 
-            ProcessBuilder pb = new ProcessBuilder(
-                    "ffmpeg",
-                    "-i", "pipe:0",            // stdin에서 webm
-                    "-vn",                     // 비디오 제거
-                    "-acodec", "libmp3lame",    // mp3 인코딩
-                    "-ar", "44100",             // 표준 mp3 샘플링
-                    "-ac", "2",                // 스테레오
-                    "-f", "mp3",               // WAV 포맷
-                    "pipe:1"                   // stdout으로 출력
-            );
-            pb.redirectErrorStream(true);
-            Process process = pb.start();
-
-            // 비디오 데이터를 쓰는 스레드
-            Thread inputThread = new Thread(() -> {
-                try (OutputStream ffmpegStdin = process.getOutputStream()) {
-                    ffmpegStdin.write(videoBytes);
-                    ffmpegStdin.flush();
-                } catch (IOException e) {
-                    log.error("ffmpeg stdin 처리 중 오류", e);
-                }
-            });
-            inputThread.start();
-
-            // 오류 출력을 읽는 스레드
-            StringBuilder errorOutput = new StringBuilder();
-            Thread errorThread = new Thread(() -> {
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        errorOutput.append(line).append("\n");
-                    }
-                } catch (IOException e) {
-                    log.error("ffmpeg stderr 읽기 중 오류", e);
-                }
-            });
-            errorThread.start();
-
-            // 2. stdout에서 오디오 bytes 읽기
-            byte[] audioBytes;
-            try (InputStream ffmpegStdout = process.getInputStream()) {
-                audioBytes = IOUtils.toByteArray(ffmpegStdout);
+        StringBuilder errorOutput = new StringBuilder();
+        Thread inputThread = new Thread(() -> {
+            try (OutputStream stdin = process.getOutputStream()) {
+                stdin.write(videoBytes);
+            } catch (IOException e) {
+                log.error("ffmpeg stdin 처리 중 오류", e);
             }
+        });
+        Thread errorThread = new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    errorOutput.append(line).append("\n");
+                }
+            } catch (IOException e) {
+                log.error("ffmpeg stderr 읽기 중 오류", e);
+            }
+        });
 
-            // 모든 스레드가 완료될 때까지 대기
+        inputThread.start();
+        errorThread.start();
+
+        byte[] audioBytes;
+        try (InputStream stdout = process.getInputStream()) {
+            audioBytes = IOUtils.toByteArray(stdout);
             inputThread.join();
             errorThread.join();
-
-            // 프로세스 완료 대기 (타임아웃 설정)
             boolean completed = process.waitFor(60, TimeUnit.SECONDS);
             if (!completed) {
                 process.destroyForcibly();
-                log.error("ffmpeg 처리 타임아웃");
-                throw new RuntimeException("ffmpeg 처리 타임아웃");
+                throw new CustomException(ErrorCode.STT_FAILED);
             }
-
-            int exitCode = process.exitValue();
-            if (exitCode != 0 || audioBytes.length == 0) {
-                log.error("ffmpeg 음성 추출 실패. 종료 코드: {}, 추출된 바이트: {}, 오류: {}", exitCode, audioBytes.length, errorOutput);
-                throw new RuntimeException("ffmpeg 음성 추출 실패. 종료 코드: " + exitCode);
-            }
-
-            log.info("ffmpeg 음성 추출 성공. 추출 크기: {} bytes", audioBytes.length);
-
-            // 3. S3에 업로드
-            S3Client s3Client = S3Client.builder()
-                    .region(REGION)
-                    .credentialsProvider(credentialsProvider)
-                    .build();
-
-            String audioFileName = "extracted-audio-" + UUID.randomUUID() + ".mp3";
-            String s3Key = "audio/" + audioFileName;
-
-            PutObjectRequest request = PutObjectRequest.builder()
-                    .bucket(BUCKET_NAME)
-                    .key(s3Key)
-                    .contentType("audio/mpeg")
-                    .build();
-
-            s3Client.putObject(request, RequestBody.fromBytes(audioBytes));
-
-            String fileUri = "s3://" + BUCKET_NAME + "/" + s3Key;
-            log.info("오디오 파일 S3 업로드 완료: {}", fileUri);
-
-            return fileUri;
-
         } catch (IOException | InterruptedException e) {
-            log.error("uploadToS3 처리 실패", e);
-            throw new RuntimeException("오디오 업로드 실패", e);
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.STT_FAILED);
         }
+
+        if (process.exitValue() != 0 || audioBytes.length == 0) {
+            log.error("ffmpeg 음성 추출 실패. 종료 코드: {}, 오류: {}", process.exitValue(), errorOutput);
+            throw new CustomException(ErrorCode.STT_FAILED);
+        }
+
+        String s3Key = "audio/extracted-" + UUID.randomUUID() + ".mp3";
+        s3Client.putObject(
+                PutObjectRequest.builder().bucket(bucket).key(s3Key).contentType("audio/mpeg").build(),
+                RequestBody.fromBytes(audioBytes)
+        );
+
+        String fileUri = "s3://" + bucket + "/" + s3Key;
+        log.info("오디오 S3 업로드 완료: {}", fileUri);
+        return fileUri;
     }
 
-    // AWS Transcribe 작업 시작
-    public static String startTranscriptionJob(AwsCredentialsProvider credentialsProvider, String s3Uri) {
-        TranscribeClient transcribeClient = TranscribeClient.builder()
-                .region(REGION)
-                .credentialsProvider(credentialsProvider)
-                .build();
-
-        String jobName = "TranscriptionJob-" + System.currentTimeMillis(); // 고유한 작업 이름 생성
-
-        StartTranscriptionJobRequest request = StartTranscriptionJobRequest.builder()
+    public String startTranscriptionJob(String s3Uri) {
+        String jobName = "TranscriptionJob-" + System.currentTimeMillis();
+        transcribeClient.startTranscriptionJob(StartTranscriptionJobRequest.builder()
                 .transcriptionJobName(jobName)
                 .media(Media.builder().mediaFileUri(s3Uri).build())
-                .mediaFormat(MediaFormat.MP3) // 오디오 형식 (MP3, WAV, FLAC 가능)
-                .languageCode(LanguageCode.KO_KR) // 한국어 인식
-                .build();
-
-        transcribeClient.startTranscriptionJob(request);
-        log.info("AWS Transcribe 변환 작업이 시작되었습니다: {}", jobName);
+                .mediaFormat(MediaFormat.MP3)
+                .languageCode(LanguageCode.KO_KR)
+                .build());
+        log.info("AWS Transcribe 작업 시작: {}", jobName);
         return jobName;
     }
 
-    // 변환된 텍스트 가져오기
-    public static String getTranscriptionResult( AwsCredentialsProvider credentialsProvider, String jobName) {
-        TranscribeClient transcribeClient = TranscribeClient.builder()
-                .region(REGION)
-                .credentialsProvider(credentialsProvider)
-                .build();
+    public String getTranscriptionResult(String jobName) {
+        for (int attempt = 1; attempt <= MAX_POLLING_ATTEMPTS; attempt++) {
+            GetTranscriptionJobResponse response = transcribeClient.getTranscriptionJob(
+                    GetTranscriptionJobRequest.builder().transcriptionJobName(jobName).build());
+            TranscriptionJob job = response.transcriptionJob();
 
-        try {
-            while (true) {
-                GetTranscriptionJobRequest request = GetTranscriptionJobRequest.builder()
-                        .transcriptionJobName(jobName)
-                        .build();
-
-                GetTranscriptionJobResponse response = transcribeClient.getTranscriptionJob(request);
-                TranscriptionJob job = response.transcriptionJob();
-
-                switch (job.transcriptionJobStatus()) {
-                    case FAILED:
-                        throw new RuntimeException("변환 작업 실패: " + job.failureReason());
-                    case COMPLETED:
-                        String transcriptUri = job.transcript().transcriptFileUri();
-                        log.info("변환 완료!");
-                        return transcriptUri; // 실제 변환된 JSON 파일을 가져오는 로직 필요
-                    default:
-                        log.info("변환 중... 상태: {}", job.transcriptionJobStatus());
-                        Thread.sleep(5000); // 5초 대기 후 재시도
-                }
+            switch (job.transcriptionJobStatus()) {
+                case FAILED:
+                    log.error("Transcribe 작업 실패: {}", job.failureReason());
+                    throw new CustomException(ErrorCode.STT_FAILED);
+                case COMPLETED:
+                    log.info("Transcribe 변환 완료: {}", jobName);
+                    return job.transcript().transcriptFileUri();
+                default:
+                    log.info("Transcribe 변환 중... 상태: {}, 시도: {}/{}", job.transcriptionJobStatus(), attempt, MAX_POLLING_ATTEMPTS);
             }
-        } catch (Exception e) {
-            throw new RuntimeException("변환 결과 가져오기 실패: " + e.getMessage());
+
+            try {
+                Thread.sleep(POLLING_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new CustomException(ErrorCode.STT_FAILED);
+            }
         }
+
+        log.error("Transcribe 폴링 타임아웃: {}", jobName);
+        throw new CustomException(ErrorCode.STT_TIMEOUT);
     }
 
-    // Json 반환
-    public static String parseTranscriptionJson(String transcriptUrl) {
+    public String parseTranscriptionJson(String transcriptUrl) {
         try (InputStream is = new URL(transcriptUrl).openStream()) {
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode rootNode = objectMapper.readTree(is);
-            return rootNode.path("results").path("transcripts").get(0).path("transcript").asText();
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(is);
+            return root.path("results").path("transcripts").get(0).path("transcript").asText();
         } catch (Exception e) {
-            throw new RuntimeException("변환된 텍스트 JSON 파싱 실패: " + e.getMessage());
+            log.error("Transcribe JSON 파싱 실패: {}", transcriptUrl, e);
+            throw new CustomException(ErrorCode.STT_FAILED);
         }
     }
 }

--- a/src/main/java/com/site/xidong/domain/feedback/service/ClaudeApiClient.java
+++ b/src/main/java/com/site/xidong/domain/feedback/service/ClaudeApiClient.java
@@ -1,0 +1,98 @@
+package com.site.xidong.domain.feedback.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.site.xidong.global.exception.CustomException;
+import com.site.xidong.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClaudeApiClient {
+
+    private static final String API_URL = "https://api.anthropic.com/v1/messages";
+    private static final String MODEL = "claude-3-7-sonnet-20250219";
+    private static final int MAX_TOKENS = 1024;
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${claude.api.key}")
+    private String apiKey;
+
+    /**
+     * Claude API를 호출해 피드백 텍스트를 반환한다.
+     */
+    public String requestFeedback(String question, String answer) {
+        String prompt = answer + "은 CS 면접 질문 [" + question + "]에 대한 답변 영상을 음성으로 변환한 후 " +
+                "STT 변환한거야. 그러니 오타라고 생각하지 말고 융통성 있게 받아들여줘. " +
+                "이 답변을 실제 개발자 채용 면접 답변이라고 생각하고 내용 측면과 전달력 측면에서 " +
+                "피드백해줘. 결과는 한국어로 전달해줘.";
+
+        String requestBody = buildRequestBody(prompt);
+        ResponseEntity<String> response = callApi(requestBody);
+        return parseResponse(response.getBody());
+    }
+
+    private String buildRequestBody(String prompt) {
+        try {
+            ObjectNode root = objectMapper.createObjectNode();
+            root.put("model", MODEL);
+            root.put("max_tokens", MAX_TOKENS);
+
+            ArrayNode messages = objectMapper.createArrayNode();
+            ObjectNode message = objectMapper.createObjectNode();
+            message.put("role", "user");
+            message.put("content", prompt);
+            messages.add(message);
+            root.set("messages", messages);
+
+            return objectMapper.writeValueAsString(root);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.AI_API_ERROR);
+        }
+    }
+
+    private ResponseEntity<String> callApi(String requestBody) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-api-key", apiKey);
+        headers.set("anthropic-version", "2023-06-01");
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    API_URL,
+                    HttpMethod.POST,
+                    new HttpEntity<>(requestBody, headers),
+                    String.class
+            );
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                log.error("Claude API 응답 오류: {}", response.getStatusCode());
+                throw new CustomException(ErrorCode.AI_API_ERROR);
+            }
+            return response;
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Claude API 호출 실패", e);
+            throw new CustomException(ErrorCode.AI_API_ERROR);
+        }
+    }
+
+    private String parseResponse(String responseBody) {
+        try {
+            ObjectNode root = objectMapper.readValue(responseBody, ObjectNode.class);
+            return root.path("content").path(0).path("text").asText();
+        } catch (Exception e) {
+            log.error("Claude API 응답 파싱 실패", e);
+            throw new CustomException(ErrorCode.AI_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/site/xidong/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/site/xidong/domain/feedback/service/FeedbackService.java
@@ -1,177 +1,81 @@
 package com.site.xidong.domain.feedback.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.site.xidong.domain.video.entity.Video;
-import com.site.xidong.domain.video.repository.VideoRepository;
-import com.site.xidong.domain.feedback.repository.FeedbackRepository;
-import com.site.xidong.global.exception.CustomException;
-import com.site.xidong.global.exception.ErrorCode;
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import com.site.xidong.domain.feedback.dto.AnswerDTO;
 import com.site.xidong.domain.feedback.dto.FeedbackReturnDTO;
 import com.site.xidong.domain.feedback.entity.Feedback;
+import com.site.xidong.domain.feedback.repository.FeedbackRepository;
+import com.site.xidong.domain.video.entity.Video;
+import com.site.xidong.domain.video.repository.VideoRepository;
+import com.site.xidong.global.exception.CustomException;
+import com.site.xidong.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Log4j2
 @Service
 @RequiredArgsConstructor
-@org.springframework.transaction.annotation.Transactional(readOnly = true)
+@Transactional(readOnly = true)
 public class FeedbackService {
-    @Value("${claude.api.key}")
-    private String API_KEY;
+
+    private final VideoRepository videoRepository;
+    private final FeedbackRepository feedbackRepository;
+    private final ClaudeApiClient claudeApiClient;
 
     @Value("${claude.mock.enabled}")
     private boolean mockEnabled;
 
-    private final VideoRepository videoRepository;
-    private final FeedbackRepository feedbackRepository;
+    @Value("${whisper.mock.delay-ms:20000}")
+    private long mockDelayMs;
 
-    @SneakyThrows
-    @org.springframework.transaction.annotation.Transactional
-    public FeedbackReturnDTO getFeedback(AnswerDTO answerDTO) { //TODO: WebClient으로 변경하기
-
-        if (mockEnabled) {
-            log.info("부하테스트 모드: Claude API 호출 생략");
-            return getMockFeedback(answerDTO);
-        }
-        Video video = videoRepository.findById(answerDTO.getVideoId()).orElse(null);
-        String question = video.getQuestion().getContents();
-        String answer = answerDTO.getAnswer();
-        String cmd = answer + "은 CS 면접 질문 [" + question + "]에 대한 답변 영상을 음성으로 변환한 후 STT 변환한거야. 그러니 오타라고 생각하지 말고 융통성 있게 받아들여줘. 이 답변을 실제 개발자 채용 면접 답변이라고 생각하고 내용 측면과 전달력 측면에서 피드백해줘. 결과는 한국어로 전달해줘.";
-
-        // Jackson 객체 매퍼 생성
-        ObjectMapper mapper = new ObjectMapper();
-        ObjectNode rootNode = mapper.createObjectNode();
-
-        // JSON 구조 설정
-        rootNode.put("model", "claude-3-7-sonnet-20250219");
-        rootNode.put("max_tokens", 1024);
-
-        ArrayNode messagesNode = mapper.createArrayNode();
-        ObjectNode messageNode = mapper.createObjectNode();
-        messageNode.put("role", "user");
-        messageNode.put("content", cmd);
-        messagesNode.add(messageNode);
-
-        rootNode.set("messages", messagesNode);
-
-        // JSON 문자열로 변환
-        String jsonInputString = mapper.writeValueAsString(rootNode);
-
-        // Claude API 요청 URL
-        URL url = new URL("https://api.anthropic.com/v1/messages");
-
-        // HTTP 연결 설정
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        connection.setRequestMethod("POST");
-        connection.setRequestProperty("x-api-key", API_KEY); // 실제 API 키로 교체
-        log.info("API KEY: " + API_KEY);
-        connection.setRequestProperty("anthropic-version", "2023-06-01");
-        connection.setRequestProperty("Content-Type", "application/json");
-        connection.setDoOutput(true);
-
-        // 요청 본문 전송
-        try (OutputStream os = connection.getOutputStream()) {
-            byte[] input = jsonInputString.getBytes("utf-8");
-            os.write(input, 0, input.length);
-        }
-
-        // 응답 처리
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream(), "utf-8"))) {
-            StringBuilder response = new StringBuilder();
-            String responseLine;
-            while ((responseLine = br.readLine()) != null) {
-                response.append(responseLine.trim());
-            }
-
-            // 응답을 FeedbackDTO로 변환하는 부분
-            String responseString = response.toString();
-
-            // Jackson을 사용하여 JSON 응답 파싱
-            ObjectNode responseNode = mapper.readValue(responseString, ObjectNode.class);
-            String content = responseNode.path("content").path(0).path("text").asText();
-
-            Feedback feedback = feedbackRepository.save(Feedback.builder()
-                    .contents(content)
-                    .video(video)
-                    .build());
-            return FeedbackReturnDTO.from(feedback);
-        } catch (IOException e) {
-            // 에러 응답 처리
-            if (connection.getResponseCode() >= 400) {
-                try (BufferedReader br = new BufferedReader(new InputStreamReader(connection.getErrorStream(), "utf-8"))) {
-                    StringBuilder errorResponse = new StringBuilder();
-                    String responseLine;
-                    while ((responseLine = br.readLine()) != null) {
-                        errorResponse.append(responseLine.trim());
-                    }
-                    log.error("API Error ({}): {}", connection.getResponseCode(), errorResponse.toString());
-                }
-            }
-            throw e;
-        }
-    }
-
-    @SneakyThrows
-    private FeedbackReturnDTO getMockFeedback(AnswerDTO answerDTO) {
+    @Transactional
+    public FeedbackReturnDTO getFeedback(AnswerDTO answerDTO) {
         Video video = videoRepository.findById(answerDTO.getVideoId())
                 .orElseThrow(() -> new CustomException(ErrorCode.VIDEO_NOT_FOUND));
 
-        String question = video.getQuestion().getContents();
-        long acceptedAt = System.currentTimeMillis();
+        String feedbackText = mockEnabled
+                ? getMockFeedbackText(video.getQuestion().getContents(), mockDelayMs)
+                : claudeApiClient.requestFeedback(video.getQuestion().getContents(), answerDTO.getAnswer());
 
-        // 실제 Claude 응답과 유사한 Mock 피드백
-        String mockContent = String.format("""
-                ### 내용 측면 피드백
-                
-                **강점:**
-                - 질문 "%s"에 대한 핵심 개념을 정확히 이해하고 있습니다.
-                - 실무 경험을 바탕으로 한 구체적인 예시가 답변의 신뢰도를 높였습니다.
-                - 기술적 깊이와 실용성의 균형이 좋습니다.
-                
-                **개선점:**
-                - 좀 더 구조화된 답변 (예: 정의 → 장단점 → 사용 사례)으로 전개하면 더 명확할 것입니다.
-                - 최신 트렌드나 대안 기술에 대한 언급이 추가되면 좋겠습니다.
-                
-                ### 전달력 측면 피드백
-                
-                **강점:**
-                - 논리적인 흐름으로 청자의 이해를 돕는 구조입니다.
-                - 적절한 발화 속도와 명확한 발음으로 전달력이 우수합니다.
-                
-                **개선점:**
-                - 중요한 포인트에서 강조나 휴지(pause)를 활용하면 더 효과적일 것입니다.
-                - 약간의 필러워드("음", "아")가 있으나 전반적으로 자연스럽습니다.
-                
-                **종합 평가:** 면접 답변으로서 매우 우수한 수준입니다. 실무 투입이 가능한 역량을 보여주고 있습니다.
-                
-                ---
-                """, question);
-
-        // 실제 처리 시뮬레이션 (약간의 지연)
-        Thread.sleep(20000);  // 실제 Claude API 호출 시간 시뮬레이션
-
-        // DB 저장 (실제와 동일)
-        Feedback feedback = feedbackRepository.save(Feedback.builder()
-                .contents(mockContent)
-                .video(video)
-                .build());
+        Feedback feedback = feedbackRepository.save(
+                Feedback.builder().contents(feedbackText).video(video).build()
+        );
         return FeedbackReturnDTO.from(feedback);
     }
 
     public Feedback findFeedback(Long feedbackId) {
-        Feedback feedback = feedbackRepository.findById(feedbackId).orElse(null);
-        return feedback;
+        return feedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ENTITY_NOT_FOUND));
+    }
+
+    private String getMockFeedbackText(String question, long delayMs) {
+        log.info("부하테스트 모드: Claude API 호출 생략 ({}ms 대기)", delayMs);
+        try {
+            Thread.sleep(delayMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return String.format("""
+                ### 내용 측면 피드백
+
+                **강점:**
+                - 질문 "%s"에 대한 핵심 개념을 정확히 이해하고 있습니다.
+                - 실무 경험을 바탕으로 한 구체적인 예시가 답변의 신뢰도를 높였습니다.
+
+                **개선점:**
+                - 좀 더 구조화된 답변으로 전개하면 더 명확할 것입니다.
+
+                ### 전달력 측면 피드백
+
+                **강점:**
+                - 논리적인 흐름으로 청자의 이해를 돕는 구조입니다.
+
+                **개선점:**
+                - 중요한 포인트에서 강조나 휴지(pause)를 활용하면 더 효과적입니다.
+
+                **종합 평가:** 면접 답변으로서 우수한 수준입니다.
+                """, question);
     }
 }

--- a/src/main/java/com/site/xidong/domain/feedback/service/LocalWhisperService.java
+++ b/src/main/java/com/site/xidong/domain/feedback/service/LocalWhisperService.java
@@ -4,12 +4,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
 public class LocalWhisperService {
+
+    private static final int TIMEOUT_SECONDS = 300;
 
     @Value("${whisper.python.path}")
     private String pythonPath;
@@ -23,111 +27,84 @@ public class LocalWhisperService {
     @Value("${whisper.mock.enabled}")
     private boolean mockEnabled;
 
-    /**
-     * S3 presigned URL에서 직접 음성 인식
-     * Python 스크립트가 FFmpeg + Whisper 처리
-     */
+    @Value("${whisper.mock.delay-ms:20000}")
+    private long mockDelayMs;
+
     public String transcribeFromUrl(String presignedUrl) {
         if (mockEnabled) {
-            log.info("[MOCK-STT] 시작");
-            try {
-                Thread.sleep(20000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            log.info("[MOCK-STT] 완료");
-            return "도커는 컨테이너 기반의 오픈소스 가상화 플랫폼입니다. 애플리케이션과 그 실행에 필요한 라이브러리, 설정, 의존성 등을 컨테이너라는 단위로 패키징해서, 어떤 환경에서든 동일하게 실행될 수 있도록 해주는 도구입니다.\n" +
-                    "\n" +
-                    "기존 가상머신과 비교하면 차이가 명확한데요, 가상머신은 하이퍼바이저 위에 Guest OS 전체를 올리기 때문에 무겁고 부팅도 느립니다. 반면 도커 컨테이너는 Host OS의 커널을 공유하기 때문에 훨씬 가볍고 빠르게 실행된다는 장점이 있습니다.\n" +
-                    "\n" +
-                    "도커의 핵심 구성요소로는 이미지, 컨테이너, Dockerfile, 그리고 Docker Hub가 있습니다. 이미지는 컨테이너를 만들기 위한 읽기 전용 템플릿이고, 컨테이너는 그 이미지를 실제로 실행한 인스턴스입니다. Dockerfile은 이미지를 어떻게 빌드할지 정의한 명세서이고, Docker Hub는 이미지를 저장하고 공유하는 레지스트리입니다.\n" +
-                    "\n" +
-                    "도커를 사용하는 가장 큰 이유는 \"내 컴퓨터에서는 되는데요?\" 라는 환경 불일치 문제를 해결할 수 있기 때문입니다. 개발, 테스트, 운영 환경을 동일하게 유지할 수 있고, 마이크로서비스 아키텍처에서 각 서비스를 독립적으로 배포하고 확장하는 데도 매우 유리합니다. 한 마디로 요약하면, 환경에 종속되지 않는 일관된 애플리케이션 실행 환경을 제공하는 플랫폼이라고 할 수 있습니다.";
+            return runMock();
         }
+
+        long start = System.currentTimeMillis();
+        log.info("Whisper STT 시작");
+
+        Process process;
         try {
-            long start = System.currentTimeMillis();
-            log.info("Whisper STT 시작: {}", presignedUrl);
+            process = new ProcessBuilder(pythonPath, scriptPath, presignedUrl, modelSize)
+                    .redirectErrorStream(false)
+                    .start();
+        } catch (IOException e) {
+            log.error("Whisper 프로세스 실행 실패", e);
+            return "";
+        }
 
-            // Python 스크립트 실행
-            ProcessBuilder pb = new ProcessBuilder(
-                    pythonPath,
-                    scriptPath,
-                    presignedUrl,
-                    modelSize
-            );
-            pb.redirectErrorStream(false);
-            Process process = pb.start();
+        StringBuilder output = new StringBuilder();
+        StringBuilder errors = new StringBuilder();
 
-            // stdout 읽기 (변환된 텍스트)
-            StringBuilder output = new StringBuilder();
-            Thread outputThread = new Thread(() -> {
-                try (BufferedReader reader = new BufferedReader(
-                        new InputStreamReader(process.getInputStream()))) {
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        output.append(line).append("\n");
-                    }
-                } catch (IOException e) {
-                    log.error("Whisper stdout 읽기 실패", e);
-                }
-            });
-            outputThread.start();
+        Thread outputThread = streamReader(process.getInputStream(), output, false);
+        Thread errorThread  = streamReader(process.getErrorStream(), errors, true);
+        outputThread.start();
+        errorThread.start();
 
-            // stderr 읽기 (에러/진행상황)
-            StringBuilder errorOutput = new StringBuilder();
-            Thread errorThread = new Thread(() -> {
-                try (BufferedReader reader = new BufferedReader(
-                        new InputStreamReader(process.getErrorStream()))) {
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        errorOutput.append(line).append("\n");
-                        if (line.contains("ERROR") || line.contains("error")) {
-                            log.warn("Whisper: {}", line);
-                        }
-                    }
-                } catch (IOException e) {
-                    log.error("Whisper stderr 읽기 실패", e);
-                }
-            });
-            errorThread.start();
-
-            // 스레드 완료 대기
+        try {
             outputThread.join();
             errorThread.join();
-
-            // 프로세스 완료 대기 (최대 5분)
-            boolean completed = process.waitFor(300, TimeUnit.SECONDS);
+            boolean completed = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!completed) {
                 process.destroyForcibly();
-                log.error("Whisper STT 타임아웃 (5분 초과)");
-                throw new RuntimeException("Whisper STT 타임아웃");
+                log.error("Whisper STT 타임아웃 ({}초 초과)", TIMEOUT_SECONDS);
+                return "";
             }
-
-            // 종료 코드 확인
-            int exitCode = process.exitValue();
-            if (exitCode != 0) {
-                log.error("Whisper STT 실패. 종료코드: {}, 에러:\n{}", exitCode, errorOutput);
-                throw new RuntimeException("Whisper STT 실패: exit code " + exitCode);
+            if (process.exitValue() != 0) {
+                log.error("Whisper STT 실패. 종료코드: {}", process.exitValue());
+                return "";
             }
-
-            // 결과 확인
-            String transcript = output.toString().trim();
-            if (transcript.isEmpty()) {
-                log.warn("Whisper 결과가 비어있음");
-            }
-
-            long duration = System.currentTimeMillis() - start;
-            log.info("Whisper STT 완료: 길이 {}, 소요시간 {}ms", transcript.length(), duration);
-
-            return transcript;
-
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.error("Whisper STT 인터럽트됨", e);
             return "";
-        } catch (Exception e) {
-            log.error("Whisper STT 실패", e);
-            return "";
         }
+
+        String transcript = output.toString().trim();
+        log.info("Whisper STT 완료: 길이={}, 소요={}ms", transcript.length(), System.currentTimeMillis() - start);
+        return transcript;
+    }
+
+    private String runMock() {
+        log.info("[MOCK-STT] {}ms 대기 후 고정 텍스트 반환", mockDelayMs);
+        try {
+            Thread.sleep(mockDelayMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return "도커는 컨테이너 기반의 오픈소스 가상화 플랫폼입니다. 애플리케이션과 그 실행에 필요한 " +
+               "라이브러리, 설정, 의존성 등을 컨테이너라는 단위로 패키징해서 어떤 환경에서든 동일하게 " +
+               "실행될 수 있도록 해주는 도구입니다.";
+    }
+
+    private Thread streamReader(java.io.InputStream stream, StringBuilder buffer, boolean warnOnError) {
+        return new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    buffer.append(line).append("\n");
+                    if (warnOnError && (line.contains("ERROR") || line.contains("error"))) {
+                        log.warn("Whisper: {}", line);
+                    }
+                }
+            } catch (IOException e) {
+                log.error("스트림 읽기 실패", e);
+            }
+        });
     }
 }

--- a/src/main/java/com/site/xidong/domain/queue/scheduler/VideoQueueProcessor.java
+++ b/src/main/java/com/site/xidong/domain/queue/scheduler/VideoQueueProcessor.java
@@ -1,0 +1,60 @@
+package com.site.xidong.domain.queue.scheduler;
+
+import com.site.xidong.domain.queue.entity.VideoProcessingQueue;
+import com.site.xidong.domain.queue.repository.VideoProcessingQueueRepository;
+import com.site.xidong.domain.video.service.VideoProcessingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VideoQueueProcessor {
+
+    private final VideoProcessingQueueRepository queueRepository;
+    private final VideoProcessingService videoProcessingService;
+
+    @Transactional
+    public void processTask(VideoProcessingQueue task) {
+        try {
+            task.markProcessing();
+            queueRepository.save(task);
+            log.info("[DB Queue] 작업 시작: {}", task.getId());
+
+            CompletableFuture<Void> future = videoProcessingService.createInitial(
+                    task.getUsername(),
+                    task.getQuestionId(),
+                    task.getRequestNo(),
+                    task.getVideoKey(),
+                    task.getIsOpen(),
+                    task.getStartTime()
+            );
+
+            future.whenComplete((result, throwable) -> updateTaskStatus(task.getId(), throwable));
+            log.info("작업 제출 완료: queueId={}", task.getId());
+        } catch (Exception e) {
+            log.error("작업 제출 실패: queueId={}", task.getId(), e);
+            task.markFailed();
+            queueRepository.save(task);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateTaskStatus(Long taskId, Throwable throwable) {
+        VideoProcessingQueue task = queueRepository.findById(taskId)
+                .orElseThrow(() -> new IllegalStateException("작업을 찾을 수 없습니다: " + taskId));
+        if (throwable != null) {
+            log.error("작업 실패: queueId={}", taskId, throwable);
+            task.markFailed();
+            queueRepository.save(task);
+        } else {
+            log.info("작업 완료: queueId={}", taskId);
+            queueRepository.delete(task);
+        }
+    }
+}

--- a/src/main/java/com/site/xidong/domain/queue/scheduler/VideoQueueScheduler.java
+++ b/src/main/java/com/site/xidong/domain/queue/scheduler/VideoQueueScheduler.java
@@ -1,6 +1,7 @@
 package com.site.xidong.domain.queue.scheduler;
 
-import com.site.xidong.domain.video.service.VideoService;
+import com.site.xidong.domain.queue.entity.VideoProcessingQueue;
+import com.site.xidong.domain.queue.repository.VideoProcessingQueueRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,99 +10,41 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import com.site.xidong.domain.queue.entity.VideoProcessingQueue;
-import com.site.xidong.domain.queue.repository.VideoProcessingQueueRepository;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class VideoQueueScheduler {
+
+    private final VideoProcessingQueueRepository queueRepository;
+    private final VideoQueueProcessor queueProcessor;
+
     @Autowired
     @Qualifier("threadPoolTaskExecutor")
     private ThreadPoolTaskExecutor videoProcessingExecutor;
 
-    private final VideoProcessingQueueRepository queueRepository;
-    private final VideoService videoService;
-
     @Scheduled(fixedDelay = 1000)
     public void processQueuedTasks() {
         try {
-            // 사용 가능한 스레드 수 계산
             int availableThreads = videoProcessingExecutor.getMaxPoolSize()
                     - videoProcessingExecutor.getActiveCount();
-
             if (availableThreads <= 0) {
-                log.info("스레드풀 포화 상태, 다음 주기 대기");
+                log.debug("스레드풀 포화 상태, 다음 주기 대기");
                 return;
             }
 
-            // 사용 가능한 스레드 수만큼만 조
             List<VideoProcessingQueue> pendingTasks = queueRepository.findPendingTasks(
-                    PageRequest.of(0, availableThreads)
-            );
-
+                    PageRequest.of(0, availableThreads));
             if (pendingTasks.isEmpty()) return;
 
             log.info("DB 큐 처리 시작: {}개 작업 발견", pendingTasks.size());
-
             for (VideoProcessingQueue task : pendingTasks) {
-                processTask(task);
+                queueProcessor.processTask(task);
             }
         } catch (Exception e) {
             log.error("스케줄러 실행 오류", e);
         }
     }
-
-    @Transactional
-    public void processTask(VideoProcessingQueue task) {
-        try {
-            // 상태 변경
-            task.markProcessing();
-            queueRepository.save(task);
-            log.info("[DB Queue] 작업 시작: ", task.getId());
-
-            // 비동기 작업 제출
-            CompletableFuture<Void> future = videoService.createInitial(
-                    task.getUsername(),
-                    task.getQuestionId(),
-                    task.getRequestNo(),
-                    task.getVideoKey(),
-                    task.getIsOpen(),
-                    task.getStartTime()
-            );
-
-            // 완료 핸들러는 별도 트랜잭션
-            future.whenComplete((result, throwable) ->
-                    updateTaskStatus(task.getId(), throwable)
-            );
-
-            log.info("작업 제출 완료: queueId={}", task.getId());
-
-        } catch (Exception e) {
-            log.error("작업 제출 실패: queueId = {}", task.getId(), e);
-            task.markFailed();
-            queueRepository.save(task);
-        }
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW) // 새 트랜잭션
-    public void updateTaskStatus(Long taskId, Throwable throwable) {
-        VideoProcessingQueue task = queueRepository.findById(taskId)
-                .orElseThrow(() -> new IllegalStateException("작업을 찾을 수 없습니다: " + taskId));
-
-        if (throwable != null) {
-            log.error("작업 실패: queueId={}", taskId, throwable);
-            task.markFailed();
-            queueRepository.save(task);
-        } else {
-            log.info("작업 완료: queueId={}", taskId);
-            queueRepository.delete(task);
-        }
-    }
-
 }

--- a/src/main/java/com/site/xidong/domain/video/service/SttService.java
+++ b/src/main/java/com/site/xidong/domain/video/service/SttService.java
@@ -1,0 +1,202 @@
+package com.site.xidong.domain.video.service;
+
+import com.site.xidong.domain.feedback.service.AwsTranscribe;
+import com.site.xidong.domain.feedback.service.LocalWhisperService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SttService {
+
+    private final S3Client s3Client;
+    private final AwsTranscribe awsTranscribe;
+    private final LocalWhisperService localWhisperService;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public double getVideoDuration(String videoKey) {
+        log.info("비디오 길이 확인 시작: {}", videoKey);
+        try {
+            HeadObjectResponse head = s3Client.headObject(
+                    HeadObjectRequest.builder().bucket(bucket).key(videoKey).build());
+
+            Map<String, String> metadata = head.metadata();
+            if (metadata.containsKey("duration")) {
+                try {
+                    double d = Double.parseDouble(metadata.get("duration"));
+                    log.info("메타데이터에서 duration 확인: {}초", d);
+                    return d;
+                } catch (NumberFormatException ignored) {
+                    log.warn("메타데이터 duration 파싱 실패, 추정 방식 사용");
+                }
+            }
+
+            long fileSizeBytes = head.contentLength();
+            if (fileSizeBytes <= 0) {
+                log.error("파일 크기를 확인할 수 없음: {}", videoKey);
+                return 0;
+            }
+            double bitrate = getEstimatedBitrate(videoKey, head.contentType());
+            double estimatedDuration = (fileSizeBytes / (1024.0 * 1024.0) * 8) / bitrate;
+            log.info("비디오 길이 추정 완료: {}초 ({}MB, {}Mbps)",
+                    Math.round(estimatedDuration),
+                    Math.round(fileSizeBytes / (1024.0 * 1024.0) * 100) / 100.0,
+                    bitrate);
+            return estimatedDuration;
+        } catch (Exception e) {
+            log.error("비디오 길이 확인 실패: {}", videoKey, e);
+            return 0;
+        }
+    }
+
+    public String transcribeShortVideo(String videoKey) {
+        try {
+            String presignedUrl = createPresignedUrl(videoKey, Duration.ofMinutes(10));
+            return localWhisperService.transcribeFromUrl(presignedUrl);
+        } catch (Exception e) {
+            log.error("짧은 영상 STT 실패: {}", videoKey, e);
+            return "";
+        }
+    }
+
+    public String transcribeLongVideo(String videoKey, double durationSeconds) {
+        log.info("긴 영상 처리 시작: {}, 길이 {}초", videoKey, durationSeconds);
+        try {
+            String presignedUrl = createPresignedUrl(videoKey, Duration.ofMinutes(60));
+            double chunkDuration = durationSeconds / 4;
+
+            ExecutorService executor = Executors.newFixedThreadPool(4);
+            List<Future<String>> futures = new ArrayList<>();
+
+            for (int i = 0; i < 4; i++) {
+                final int chunkIndex = i;
+                final double startSec = i * chunkDuration;
+                futures.add(executor.submit(() -> transcribeChunk(presignedUrl, chunkIndex, startSec, chunkDuration)));
+            }
+
+            List<String> transcripts = new ArrayList<>();
+            for (Future<String> future : futures) {
+                try {
+                    String t = future.get();
+                    if (t != null && !t.trim().isEmpty()) transcripts.add(t);
+                } catch (Exception e) {
+                    log.error("청크 처리 중 오류: {}", e.getMessage());
+                }
+            }
+
+            executor.shutdown();
+            if (!executor.awaitTermination(60, TimeUnit.MINUTES)) executor.shutdownNow();
+
+            String combined = String.join(" ", transcripts);
+            log.info("긴 영상 텍스트 병합 완료: 길이={}", combined.length());
+            return combined;
+        } catch (Exception e) {
+            log.error("긴 영상 STT 실패: {}", videoKey, e);
+            return "";
+        }
+    }
+
+    private String transcribeChunk(String presignedUrl, int chunkIndex, double startSec, double durationSec) throws Exception {
+        Path tempChunk = Files.createTempFile("chunk-" + chunkIndex + "-", ".webm");
+        Path tempAudio = Files.createTempFile("audio-" + chunkIndex + "-", ".mp3");
+        try {
+            extractChunk(presignedUrl, tempChunk, startSec, durationSec);
+            convertToMp3(tempChunk, tempAudio);
+
+            String audioKey = "audio/chunk-" + chunkIndex + "-" + UUID.randomUUID() + ".mp3";
+            s3Client.putObject(
+                    PutObjectRequest.builder().bucket(bucket).key(audioKey).contentType("audio/mpeg").build(),
+                    RequestBody.fromFile(tempAudio));
+
+            String audioUri = "s3://" + bucket + "/" + audioKey;
+            String jobName = awsTranscribe.startTranscriptionJob(audioUri);
+            String transcriptUri = awsTranscribe.getTranscriptionResult(jobName);
+            String transcript = awsTranscribe.parseTranscriptionJson(transcriptUri);
+            log.info("청크 {} 음성 변환 완료: 길이={}", chunkIndex, transcript.length());
+            return transcript;
+        } finally {
+            Files.deleteIfExists(tempChunk);
+            Files.deleteIfExists(tempAudio);
+        }
+    }
+
+    private void extractChunk(String presignedUrl, Path output, double startSec, double durationSec) throws Exception {
+        Process p = new ProcessBuilder(
+                "ffmpeg", "-i", presignedUrl,
+                "-ss", String.format("%.2f", startSec),
+                "-t", String.format("%.2f", durationSec),
+                "-c:v", "copy", "-c:a", "copy",
+                output.toString()
+        ).redirectErrorStream(true).start();
+        p.getInputStream().transferTo(OutputStream.nullOutputStream());
+        p.waitFor(60, TimeUnit.SECONDS);
+    }
+
+    private void convertToMp3(Path input, Path output) throws Exception {
+        Process p = new ProcessBuilder(
+                "ffmpeg", "-i", input.toString(),
+                "-vn", "-acodec", "libmp3lame", "-ar", "44100", "-ac", "2", "-f", "mp3",
+                output.toString()
+        ).redirectErrorStream(true).start();
+        p.getInputStream().transferTo(OutputStream.nullOutputStream());
+        p.waitFor(60, TimeUnit.SECONDS);
+    }
+
+    private String createPresignedUrl(String videoKey, Duration duration) {
+        try (S3Presigner presigner = S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build()) {
+            PresignedGetObjectRequest req = presigner.presignGetObject(r -> r
+                    .signatureDuration(duration)
+                    .getObjectRequest(GetObjectRequest.builder().bucket(bucket).key(videoKey).build()));
+            return req.url().toString();
+        }
+    }
+
+    private double getEstimatedBitrate(String videoKey, String contentType) {
+        if (contentType != null) {
+            String ct = contentType.toLowerCase();
+            if (ct.contains("webm")) return 2.0;
+            if (ct.contains("mp4"))  return 3.0;
+            if (ct.contains("avi"))  return 4.0;
+            if (ct.contains("mov"))  return 3.5;
+            if (ct.contains("mkv"))  return 2.5;
+        }
+        String key = videoKey.toLowerCase();
+        if (key.endsWith(".webm")) return 2.0;
+        if (key.endsWith(".mp4"))  return 3.0;
+        if (key.endsWith(".avi"))  return 4.0;
+        if (key.endsWith(".mov"))  return 3.5;
+        if (key.endsWith(".mkv"))  return 2.5;
+        if (key.endsWith(".flv"))  return 1.5;
+        if (key.endsWith(".wmv"))  return 2.0;
+        if (key.endsWith(".m4v"))  return 3.0;
+        return 2.5;
+    }
+}

--- a/src/main/java/com/site/xidong/domain/video/service/ThumbnailService.java
+++ b/src/main/java/com/site/xidong/domain/video/service/ThumbnailService.java
@@ -1,0 +1,169 @@
+package com.site.xidong.domain.video.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bytedeco.javacv.FFmpegFrameGrabber;
+import org.bytedeco.javacv.Frame;
+import org.bytedeco.javacv.Java2DFrameConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+import javax.imageio.*;
+import javax.imageio.stream.FileImageOutputStream;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Iterator;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ThumbnailService {
+
+    private static final String DEFAULT_THUMBNAIL_URL =
+            "https://dive-s3-ver2.s3.ap-northeast-2.amazonaws.com/Gk9C7kwWkAATlwl.jpeg";
+    private static final float JPEG_QUALITY = 0.85f;
+    private static final int THUMB_MAX_WIDTH = 800;
+    private static final int THUMB_MAX_HEIGHT = 600;
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    /**
+     * S3에서 presigned URL로 영상을 가져와 첫 프레임을 썸네일로 생성하고 S3에 업로드한다.
+     *
+     * @return 업로드된 썸네일의 S3 public URL (실패 시 기본 이미지 URL)
+     */
+    public String generate(String videoKey) {
+        String thumbnailKey = videoKey.replace(".webm", "-thumb.jpg");
+        try {
+            String presignedUrl = createPresignedUrl(videoKey, Duration.ofMinutes(10));
+            Path tempFile = extractFirstFrame(presignedUrl, videoKey);
+            if (tempFile == null) return DEFAULT_THUMBNAIL_URL;
+
+            uploadToS3(tempFile, thumbnailKey);
+            Files.delete(tempFile);
+            return s3UrlOf(thumbnailKey);
+        } catch (Exception e) {
+            log.warn("썸네일 생성 실패, 기본 이미지 사용: {}", e.getMessage());
+            return DEFAULT_THUMBNAIL_URL;
+        }
+    }
+
+    private String createPresignedUrl(String videoKey, Duration duration) {
+        try (S3Presigner presigner = S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build()) {
+            GetObjectRequest getReq = GetObjectRequest.builder().bucket(bucket).key(videoKey).build();
+            PresignedGetObjectRequest presigned = presigner.presignGetObject(r -> r
+                    .signatureDuration(duration)
+                    .getObjectRequest(getReq));
+            return presigned.url().toString();
+        }
+    }
+
+    private Path extractFirstFrame(String presignedUrl, String videoKey) throws IOException {
+        Path tempFile = Files.createTempFile("thumb_", ".jpg");
+        FFmpegFrameGrabber grabber = new FFmpegFrameGrabber(presignedUrl);
+        try {
+            grabber.setOption("threads", "auto");
+            grabber.setOption("analyzeduration", "1000000");
+            grabber.setOption("probesize", "1000000");
+            grabber.start();
+            grabber.setTimestamp(1000);
+
+            Frame frame = grabber.grabImage();
+            if (frame == null) frame = grabber.grabImage();
+            if (frame == null) {
+                log.error("프레임 추출 실패: {}", videoKey);
+                return null;
+            }
+
+            Java2DFrameConverter converter = new Java2DFrameConverter();
+            BufferedImage image = converter.convert(frame);
+            if (image == null) {
+                log.error("프레임 → 이미지 변환 실패");
+                return null;
+            }
+
+            saveAsJpeg(resizeImage(image), tempFile.toFile());
+            log.info("썸네일 프레임 추출 완료: {} bytes", Files.size(tempFile));
+            return tempFile;
+        } finally {
+            try { grabber.stop(); grabber.release(); } catch (Exception e) {
+                log.warn("FFmpegFrameGrabber 해제 실패: {}", e.getMessage());
+            }
+        }
+    }
+
+    private void uploadToS3(Path file, String key) {
+        s3Client.putObject(
+                PutObjectRequest.builder()
+                        .bucket(bucket).key(key)
+                        .contentType("image/jpeg")
+                        .acl(ObjectCannedACL.PUBLIC_READ)
+                        .build(),
+                RequestBody.fromFile(file)
+        );
+        log.info("썸네일 S3 업로드 완료: {}", key);
+    }
+
+    private BufferedImage resizeImage(BufferedImage original) {
+        double scale = Math.min(
+                (double) THUMB_MAX_WIDTH / original.getWidth(),
+                (double) THUMB_MAX_HEIGHT / original.getHeight()
+        );
+        if (scale >= 1.0) return original;
+
+        int w = (int) (original.getWidth() * scale);
+        int h = (int) (original.getHeight() * scale);
+        BufferedImage resized = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = resized.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g.setRenderingHint(RenderingHints.KEY_RENDERING,     RenderingHints.VALUE_RENDER_QUALITY);
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING,  RenderingHints.VALUE_ANTIALIAS_ON);
+        g.drawImage(original, 0, 0, w, h, null);
+        g.dispose();
+        return resized;
+    }
+
+    private void saveAsJpeg(BufferedImage image, File output) throws IOException {
+        Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("jpeg");
+        if (!writers.hasNext()) throw new IllegalStateException("JPEG writer를 찾을 수 없습니다");
+        ImageWriter writer = writers.next();
+        ImageWriteParam param = writer.getDefaultWriteParam();
+        if (param.canWriteCompressed()) {
+            param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+            param.setCompressionQuality(JPEG_QUALITY);
+        }
+        try (FileImageOutputStream out = new FileImageOutputStream(output)) {
+            writer.setOutput(out);
+            writer.write(null, new IIOImage(image, null, null), param);
+        } finally {
+            writer.dispose();
+        }
+    }
+
+    private String s3UrlOf(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
+    }
+}

--- a/src/main/java/com/site/xidong/domain/video/service/VideoProcessingService.java
+++ b/src/main/java/com/site/xidong/domain/video/service/VideoProcessingService.java
@@ -1,0 +1,173 @@
+package com.site.xidong.domain.video.service;
+
+import com.site.xidong.domain.feedback.dto.AnswerDTO;
+import com.site.xidong.domain.feedback.dto.FeedbackReturnDTO;
+import com.site.xidong.domain.feedback.entity.Feedback;
+import com.site.xidong.domain.feedback.service.FeedbackService;
+import com.site.xidong.domain.notification.dto.VideoNotificationDTO;
+import com.site.xidong.domain.notification.service.NotificationService;
+import com.site.xidong.domain.question.entity.Question;
+import com.site.xidong.domain.question.exception.QuestionNotFoundException;
+import com.site.xidong.domain.question.repository.QuestionRepository;
+import com.site.xidong.domain.user.entity.SiteUser;
+import com.site.xidong.domain.user.repository.SiteUserRepository;
+import com.site.xidong.domain.video.entity.Video;
+import com.site.xidong.domain.video.repository.VideoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VideoProcessingService {
+
+    private final VideoRepository videoRepository;
+    private final SiteUserRepository siteUserRepository;
+    private final QuestionRepository questionRepository;
+    private final ThumbnailService thumbnailService;
+    private final SttService sttService;
+    private final FeedbackService feedbackService;
+    private final NotificationService notificationService;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Async("videoProcessingExecutor")
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public CompletableFuture<Void> createInitial(
+            String username, Long questionId, int requestNo,
+            String videoKey, Boolean isOpen, long startTime) {
+        try {
+            SiteUser user = siteUserRepository.findSiteUserByUsername(username)
+                    .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다: " + username));
+            Question question = questionRepository.findById(questionId)
+                    .orElseThrow(QuestionNotFoundException::new);
+
+            String videoUrl = String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, videoKey);
+            Video video = Video.builder()
+                    .videoPath(videoUrl)
+                    .videoName(videoKey)
+                    .siteUser(user)
+                    .question(question)
+                    .isOpen(isOpen)
+                    .processingStatus("PROCESSING")
+                    .build();
+            Video saved = videoRepository.save(video);
+            log.info("비디오 초기 저장 완료: ID={}", saved.getId());
+
+            processVideo(saved.getId(), requestNo, videoKey, username, startTime);
+
+            return CompletableFuture.completedFuture(null);
+        } catch (Exception e) {
+            log.error("비디오 초기 처리 실패", e);
+            throw new RuntimeException("비디오 초기 처리에 실패했습니다", e);
+        }
+    }
+
+    // Direct call is fine: @Transactional(REQUIRED) joins the REQUIRES_NEW tx already in ThreadLocal.
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void processVideo(Long videoId, int requestNo, String videoKey, String username, long startTime) {
+        long procStart = System.currentTimeMillis();
+        try {
+            double durationSeconds = sttService.getVideoDuration(videoKey);
+            boolean isLongVideo = durationSeconds > 300;
+
+            String thumbnailUrl = thumbnailService.generate(videoKey);
+            updateVideoThumbnailAndStatus(videoId, thumbnailUrl);
+
+            String answer = isLongVideo
+                    ? sttService.transcribeLongVideo(videoKey, durationSeconds)
+                    : sttService.transcribeShortVideo(videoKey);
+
+            log.info("STT 완료: videoId={}, 길이={}, 소요={}ms",
+                    videoId, answer.length(), System.currentTimeMillis() - procStart);
+
+            if (!isValidAnswer(answer)) {
+                log.warn("유효한 답변 없음: videoId={}", videoId);
+                handleInvalidAnswer(videoId, username, answer);
+                return;
+            }
+
+            handleValidAnswer(videoId, username, answer);
+
+            log.info("비디오 처리 완료: videoId={}, requestNo={}, 총 소요={}ms",
+                    videoId, requestNo, System.currentTimeMillis() - startTime);
+        } catch (Exception e) {
+            log.error("비디오 비동기 처리 중 오류: videoId={}", videoId, e);
+            handleError(videoId, username);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void updateVideoThumbnailAndStatus(Long videoId, String thumbnailUrl) {
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> new RuntimeException("Video not found: " + videoId));
+        video.updateThumbnail(thumbnailUrl);
+        video.updateStatus("TRANSCRIBING");
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void handleInvalidAnswer(Long videoId, String username, String answer) {
+        log.warn("유효한 답변 없음: videoId={}, answer='{}'", videoId, answer);
+        videoRepository.findById(videoId).ifPresent(video -> {
+            video.updateStatus("NO_RESPONSE");
+            notificationService.send(username, "video-processed",
+                    VideoNotificationDTO.builder()
+                            .videoId(videoId).status("NO_RESPONSE")
+                            .message("녹화된 답변이 감지되지 않았습니다. 다시 시도해주세요.")
+                            .build());
+        });
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void handleValidAnswer(Long videoId, String username, String answer) {
+        long start = System.currentTimeMillis();
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> new RuntimeException("Video not found: " + videoId));
+
+        FeedbackReturnDTO feedbackDTO = feedbackService.getFeedback(
+                AnswerDTO.builder().videoId(videoId).answer(answer).build());
+        Feedback feedback = feedbackService.findFeedback(feedbackDTO.getFeedbackId());
+
+        video.updateStatus("COMPLETED");
+        video.linkFeedback(feedback);
+
+        notificationService.send(username, "video-processed",
+                VideoNotificationDTO.builder()
+                        .videoId(videoId).status("COMPLETED")
+                        .message("비디오 처리가 완료되었습니다.")
+                        .feedbackId(feedbackDTO.getFeedbackId())
+                        .build());
+
+        log.info("피드백 생성 완료: videoId={}, 소요={}ms", videoId, System.currentTimeMillis() - start);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void handleError(Long videoId, String username) {
+        videoRepository.findById(videoId).ifPresent(video -> {
+            video.updateStatus("ERROR");
+            notificationService.send(username, "video-processed",
+                    VideoNotificationDTO.builder()
+                            .videoId(videoId).status("ERROR")
+                            .message("비디오 처리 중 오류가 발생했습니다.")
+                            .build());
+        });
+    }
+
+    private boolean isValidAnswer(String answer) {
+        return answer != null
+                && !answer.trim().isEmpty()
+                && answer.trim().length() >= 10
+                && !answer.trim().matches("(?i).*\\b(background noise|unintelligible|inaudible)\\b.*");
+    }
+}

--- a/src/main/java/com/site/xidong/domain/video/service/VideoService.java
+++ b/src/main/java/com/site/xidong/domain/video/service/VideoService.java
@@ -1,67 +1,28 @@
 package com.site.xidong.domain.video.service;
 
-import com.site.xidong.domain.feedback.entity.Feedback;
-import com.site.xidong.domain.feedback.dto.AnswerDTO;
 import com.site.xidong.domain.feedback.dto.FeedbackReturnDTO;
+import com.site.xidong.domain.feedback.entity.Feedback;
 import com.site.xidong.domain.feedback.service.FeedbackService;
-import com.site.xidong.domain.feedback.service.LocalWhisperService;
-import com.site.xidong.domain.notification.service.NotificationService;
-import com.site.xidong.domain.notification.dto.VideoNotificationDTO;
-import com.site.xidong.domain.question.entity.Question;
 import com.site.xidong.domain.question.exception.QuestionNotFoundException;
-import com.site.xidong.domain.question.repository.QuestionRepository;
 import com.site.xidong.domain.queue.entity.VideoProcessingQueue;
 import com.site.xidong.domain.queue.repository.VideoProcessingQueueRepository;
-import com.site.xidong.domain.user.entity.SiteUser;
-import com.site.xidong.domain.user.repository.SiteUserRepository;
+import com.site.xidong.domain.video.dto.VideoReturnDTO;
+import com.site.xidong.domain.video.dto.VideoWithFeedbackDTO;
+import com.site.xidong.domain.video.entity.Video;
+import com.site.xidong.domain.video.repository.VideoRepository;
 import com.site.xidong.global.exception.CustomException;
 import com.site.xidong.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
-import org.bytedeco.javacv.FFmpegFrameGrabber;
-import org.bytedeco.javacv.Frame;
-import org.bytedeco.javacv.Java2DFrameConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.embedded.tomcat.TomcatWebServer;
-import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.*;
-import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
-import javax.imageio.IIOImage;
-import javax.imageio.ImageIO;
-import javax.imageio.ImageWriteParam;
-import javax.imageio.ImageWriter;
-import javax.imageio.stream.FileImageOutputStream;
-import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.*;
 import java.util.List;
-import java.util.concurrent.*;
-import com.site.xidong.domain.feedback.service.AwsTranscribe;
-import com.site.xidong.domain.video.entity.Video;
-import com.site.xidong.domain.video.repository.VideoRepository;
-import com.site.xidong.domain.video.dto.VideoReturnDTO;
-import com.site.xidong.domain.video.dto.VideoWithFeedbackDTO;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @Slf4j
 @Service
@@ -69,779 +30,29 @@ import com.site.xidong.domain.video.dto.VideoWithFeedbackDTO;
 @RequiredArgsConstructor
 public class VideoService {
 
-    private static final String DEFAULT_THUMBNAIL_URL = "https://dive-s3-ver2.s3.ap-northeast-2.amazonaws.com/Gk9C7kwWkAATlwl.jpeg";
     private static final int CORE_POOL_SIZE = 10;
     private static final int QUEUE_CAPACITY = 50;
     private static final double CAPACITY_THRESHOLD = 0.8;
+
     private final VideoRepository videoRepository;
-    private final SiteUserRepository siteUserRepository;
-    private final QuestionRepository questionRepository;
-    private final AwsTranscribe awsTranscribe;
     private final FeedbackService feedbackService;
-    private final NotificationService notificationService;
     private final VideoProcessingQueueRepository queueRepository;
-    private final LocalWhisperService localWhisperService;
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
-    @Value("${cloud.aws.region.static}")
-    private String region;
+    private final VideoProcessingService videoProcessingService;
 
     @Autowired
     @Qualifier("threadPoolTaskExecutor")
     private ThreadPoolTaskExecutor videoProcessingExecutor;
 
-    @Autowired
-    private ServletWebServerApplicationContext context;
-
-    @Autowired @Lazy
-    private VideoService self;
-
-    private String getS3UrlPrefix() {
-        return "https://" + bucket + ".s3." + region + ".amazonaws.com";
-    }
-
-    @Async("videoProcessingExecutor")
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public CompletableFuture<Void> createInitial(String username, Long questionId, int requestNo, String videoKey, Boolean isOpen, long startTime) {
-        try {
-            SiteUser user = siteUserRepository.findSiteUserByUsername(username)
-                    .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다."));
-
-            Question question = questionRepository.findById(questionId)
-                    .orElseThrow(() -> new QuestionNotFoundException());
-
-            // 비디오 URL 생성
-            String videoUrl = String.format("%s/%s", getS3UrlPrefix(), videoKey);
-
-            // Step 5: Video 객체 생성 및 저장
-            Video video = Video.builder()
-                    .videoPath(videoUrl)
-                    .videoName(videoKey)
-                    .siteUser(user)
-                    .question(question)
-                    .isOpen(isOpen)
-                    .processingStatus("PROCESSING")
-                    .build();
-
-            Video savedVideo = videoRepository.save(video);
-            log.info("비디오 초기 저장 완료: ID={}", savedVideo.getId());
-
-            self.processVideo(savedVideo.getId(), requestNo, videoKey, user.getUsername(), startTime);
-
-            return CompletableFuture.completedFuture(null);
-
-        } catch (Exception e) {
-            log.error("비디오 초기 처리 실패", e);
-            throw new RuntimeException("비디오 초기 처리에 실패했습니다", e);
-        }
-    }
-
-    @Transactional(propagation = Propagation.REQUIRED) // 트랜잭션 전파 기법: 기존 트랜잭션 사용
-    public void processVideo(Long videoId, int requestNo, String videoKey, String username, long startTime) {
-
-        long procStart = System.currentTimeMillis();
-
-        try {
-            // S3 클라이언트 초기화
-            AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
-            S3Client s3Client = S3Client.builder()
-                    .region(Region.AP_NORTHEAST_2)
-                    .credentialsProvider(credentialsProvider)
-                    .build();
-
-            // 비디오 길이 확인
-            long start = System.currentTimeMillis();
-            double durationInSeconds = getVideoDurationFromS3(s3Client, bucket, videoKey); // FFmpeg로 길이 확인
-            boolean isLongVideo = durationInSeconds > 300; // 5분 이상
-            long end = System.currentTimeMillis();
-            long duration = end - start;
-            long afterDuration = System.currentTimeMillis() - procStart;
-            // 썸네일 생성 (Presigned URL 사용)
-            start = System.currentTimeMillis();
-            String thumbnailKey = videoKey.replace(".webm", "-thumb.jpg");
-            String thumbnailUrl = "";
-            thumbnailUrl = createThumbnailWithPresignedUrl(s3Client, videoKey, thumbnailKey);
-            end = System.currentTimeMillis();
-            duration = end - start;
-            long afterThumbnail = System.currentTimeMillis() - procStart;
-
-            // 비디오 상태 업데이트
-            updateVideoThumbnailAndStatus(videoId, thumbnailUrl);
-
-            // 오디오 처리
-            String answer = "";
-            if (isLongVideo) {
-                log.info("긴 영상 처리: {} 초", durationInSeconds);
-                answer = processLongVideoWithPresignedUrl(s3Client, videoId, videoKey, durationInSeconds);
-            } else {
-                log.info("짧은 영상 처리: {} 초", durationInSeconds);
-                answer = processShortVideoWithPresignedUrl(s3Client, videoId, videoKey);
-            }
-
-            long afterSTT = System.currentTimeMillis() - procStart;
-
-            // 답변 유효성 검사
-            boolean isValidAnswer = isValidAnswer(answer);
-
-            log.info("답변 유효성 검사 결과: {}, 정제된 텍스트 길이: {}",
-                    isValidAnswer,
-                    answer != null ? answer.trim().length() : 0);
-
-            if (!isValidAnswer) {
-                log.warn("비디오 ID: {} 유효한 답변이 없습니다. 원본 답변: '{}'", videoId, answer);
-
-                handleInvalidAnswer(videoId, username, answer);
-                return; // 함수 종료
-            }
-
-            // 피드백 처리 및 최종 업데이트
-            handleValidAnswer(videoId, username, answer);
-
-            long afterFeedback = System.currentTimeMillis() - procStart;
-
-            long completedAt = System.currentTimeMillis();
-            String threadName = Thread.currentThread().getName();
-            String threadType = threadName.contains("http-nio") ? "Tomcat" : "Java";
-
-            int poolSize = 0; int activeCount = 0;
-            if (threadType.equals("Tomcat")) {
-                TomcatWebServer tomcatWebServer = (TomcatWebServer) context.getWebServer();
-                ThreadPoolExecutor tomcatExecutor = (ThreadPoolExecutor) tomcatWebServer
-                        .getTomcat()
-                        .getConnector()
-                        .getProtocolHandler()
-                        .getExecutor();
-
-                poolSize = tomcatExecutor.getPoolSize();
-                activeCount = tomcatExecutor.getActiveCount();
-            } else {
-                poolSize = videoProcessingExecutor.getPoolSize();
-                activeCount = videoProcessingExecutor.getActiveCount();
-            }
-            log.info("videoId={}, requestNo={}, thread={}, threadType={}," +
-                            " poolSize={}, activeCount={}," +
-                            " acceptedAt={}, completedAt={}, duration={}ms, heap={}MB",
-                    videoId, requestNo, threadName, threadType,
-                    poolSize,
-                    activeCount,
-                    startTime, completedAt, (completedAt - startTime),
-                    (Runtime.getRuntime().totalMemory()
-                            - Runtime.getRuntime().freeMemory()) / 1024 / 1024); //근사값
-        } catch (Exception e) {
-            log.error("비디오 ID: {} 비동기 처리 중 오류 발생", videoId, e);
-            handleError(videoId, username);
-        }
-    }
-
-    @Transactional(propagation = Propagation.REQUIRED)
-    public void updateVideoThumbnailAndStatus(Long videoId, String thumbnailUrl) {
-        Video video = videoRepository.findById(videoId)
-                .orElseThrow(() -> new RuntimeException("Video not found with id: " + videoId));
-        video.updateThumbnail(thumbnailUrl);
-        video.updateStatus("TRANSCRIBING");
-        videoRepository.save(video);
-    }
-
-    @Transactional(propagation = Propagation.REQUIRED)
-    public void handleInvalidAnswer(Long videoId, String username, String answer) {
-        log.warn("비디오 ID: {} 유효한 답변이 없습니다. 원본 답변: '{}'", videoId, answer);
-        Video video = videoRepository.findById(videoId).orElse(null);
-        if (video != null) {
-            video.updateStatus("NO_RESPONSE");
-            videoRepository.save(video);
-            VideoNotificationDTO noResponseData = VideoNotificationDTO.builder()
-                    .videoId(videoId)
-                    .status("NO_RESPONSE")
-                    .message("녹화된 답변이 감지되지 않았습니다. 다시 시도해주세요.")
-                    .build();
-            notificationService.send(username, "video-processed", noResponseData);
-        }
-    }
-
-    @Transactional(propagation = Propagation.REQUIRED)
-    public void handleValidAnswer(Long videoId, String username, String answer) {
-        long start = System.currentTimeMillis();
-        Video video = videoRepository.findById(videoId)
-                .orElseThrow(() -> new RuntimeException("Video not found with id: " + videoId));
-        AnswerDTO answerDTO = AnswerDTO.builder()
-                .videoId(videoId)
-                .answer(answer)
-                .build();
-        FeedbackReturnDTO feedbackReturnDTO = feedbackService.getFeedback(answerDTO);
-        Feedback feedback = feedbackService.findFeedback(feedbackReturnDTO.getFeedbackId());
-        video.updateStatus("COMPLETED");
-        video.linkFeedback(feedback);
-        videoRepository.save(video);
-
-        VideoNotificationDTO notification = VideoNotificationDTO.builder()
-                .videoId(videoId)
-                .status("COMPLETED")
-                .message("비디오 처리가 완료되었습니다.")
-                .feedbackId(feedbackReturnDTO.getFeedbackId())
-                .build();
-        notificationService.send(username, "video-processed", notification);
-        log.info("비디오 ID: {} 처리 완료 알림 전송됨", videoId);
-        long end = System.currentTimeMillis();
-        long duration = end - start;
-        log.info("피드백 생성 소요 시간: {}ms", duration);
-    }
-
-    @Transactional(propagation = Propagation.REQUIRED)
-    public void handleError(Long videoId, String username) {
-        Video video = videoRepository.findById(videoId).orElse(null);
-        if (video != null) {
-            video.updateStatus("ERROR");
-            videoRepository.save(video);
-            VideoNotificationDTO errorData = VideoNotificationDTO.builder()
-                    .videoId(videoId)
-                    .status("ERROR")
-                    .message("비디오 처리 중 오류가 발생했습니다.")
-                    .build();
-            notificationService.send(username, "video-processed", errorData);
-        }
-    }
-
-    private boolean isValidAnswer(String answer) {
-        return answer != null &&
-                !answer.trim().isEmpty() &&
-                answer.trim().length() >= 10 &&
-                !answer.trim().matches("(?i).*\\\\b(background noise|unintelligible|inaudible)\\\\b.*");
-    }
-
-    private double getVideoDurationFromS3(S3Client s3Client, String bucket, String videoKey) {
-        log.info("비디오 길이 확인 시작: {}", videoKey);
-
-        try {
-            // 1. HTTP HEAD 요청으로 파일 크기와 메타데이터만 확인 (0.2-1초)
-            HeadObjectRequest headRequest = HeadObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(videoKey)
-                    .build();
-
-            HeadObjectResponse headResponse = s3Client.headObject(headRequest);
-
-            // 2. 메타데이터에 실제 duration이 있으면 우선 사용 (가장 정확)
-            log.info("메타데이터로 비디오 길이 확인");
-            Map<String, String> metadata = headResponse.metadata();
-            if (metadata.containsKey("duration")) {
-                try {
-                    double duration = Double.parseDouble(metadata.get("duration"));
-                    log.info("메타데이터에서 duration 확인: {}초 ({})", duration, videoKey);
-                    return duration;
-                } catch (NumberFormatException e) {
-                    log.warn("메타데이터 duration 파싱 실패, 추정 방식 사용: {}", videoKey);
-                }
-            }
-
-            // 3. 파일 크기 기반 duration 추정
-            log.info("파일 크기 기반으로 비디오 길이 확인");
-            long fileSizeBytes = headResponse.contentLength();
-            String contentType = headResponse.contentType();
-
-            if (fileSizeBytes <= 0) {
-                log.error("파일 크기를 확인할 수 없음: {}", videoKey);
-                return 0;
-            }
-
-            // 4. 파일 확장자와 Content-Type으로 예상 비트레이트 결정
-            double estimatedBitrateMbps = getEstimatedBitrate(videoKey, contentType);
-
-            // 5. Duration 계산: 파일크기(MB) ÷ 비트레이트(Mbps) = 초
-            double fileSizeMB = fileSizeBytes / (1024.0 * 1024.0);
-            double estimatedDuration = (fileSizeMB * 8) / estimatedBitrateMbps; // 8 bits per byte
-
-            log.info("초고속 비디오 길이 추정 완료: {}초 (파일: {}MB, 예상비트레이트: {}Mbps) - {}",
-                    Math.round(estimatedDuration), Math.round(fileSizeMB * 100) / 100.0, estimatedBitrateMbps, videoKey);
-
-            return estimatedDuration;
-
-        } catch (Exception e) {
-            log.error("초고속 비디오 길이 확인 실패: {}", videoKey, e);
-            return 0;
-        }
-    }
-
-    /**
-     * 파일 형식별 예상 비트레이트 반환 (Mbps)
-     * 실제 사용 데이터를 기반으로 지속적으로 조정 필요
-     */
-    private double getEstimatedBitrate(String videoKey, String contentType) {
-        String fileName = videoKey.toLowerCase();
-
-        // Content-Type 우선 확인
-        if (contentType != null) {
-            contentType = contentType.toLowerCase();
-            if (contentType.contains("webm")) return 2.0;
-            if (contentType.contains("mp4")) return 3.0;
-            if (contentType.contains("avi")) return 4.0;
-            if (contentType.contains("mov")) return 3.5;
-            if (contentType.contains("mkv")) return 2.5;
-        }
-
-        // 파일 확장자로 추정
-        if (fileName.endsWith(".webm")) return 2.0;      // WebM: 효율적 압축
-        if (fileName.endsWith(".mp4")) return 3.0;       // MP4: 일반적
-        if (fileName.endsWith(".avi")) return 4.0;       // AVI: 큰 용량
-        if (fileName.endsWith(".mov")) return 3.5;       // MOV: 고품질
-        if (fileName.endsWith(".mkv")) return 2.5;       // MKV: 가변적
-        if (fileName.endsWith(".flv")) return 1.5;       // FLV: 낮은 품질
-        if (fileName.endsWith(".wmv")) return 2.0;       // WMV: 압축률 좋음
-        if (fileName.endsWith(".m4v")) return 3.0;       // M4V: MP4와 유사
-
-        // 기본값: 중간 비트레이트
-        return 2.5;
-    }
-
-
-    // 짧은 비디오 처리
-    private String processShortVideoWithPresignedUrl(S3Client s3Client, Long videoId, String videoKey) {
-        try {
-            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(videoKey)
-                    .build();
-            try (S3Presigner presigner = S3Presigner.builder()
-                    .region(Region.AP_NORTHEAST_2)
-                    .credentialsProvider(DefaultCredentialsProvider.create())
-                    .build()) {
-                PresignedGetObjectRequest presignedRequest = presigner.presignGetObject(r -> r
-                        .signatureDuration(Duration.ofMinutes(10))
-                        .getObjectRequest(getObjectRequest));
-                String presignedUrl = presignedRequest.url().toString();
-
-                return localWhisperService.transcribeFromUrl(presignedUrl);
-            }
-        } catch (Exception e) {
-            log.error("짧은 영상 처리 실패: 비디오 ID {}", videoId, e);
-            return "";
-        }
-    }
-
-    private String processShortVideo(byte[] videoBytes) {
-        long start = System.currentTimeMillis();
-        AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
-
-        // S3에 오디오 파일 업로드
-        String audioUri = awsTranscribe.uploadToS3(credentialsProvider, videoBytes);
-        log.info("오디오 S3 업로드 완료: {}", audioUri);
-
-        long end = System.currentTimeMillis();
-        long duration = end - start;
-        log.info("음성 변환 소요 시간: {}ms", duration);
-
-        start = System.currentTimeMillis();
-        // AWS Transcribe 작업 시작
-        String jobName = awsTranscribe.startTranscriptionJob(credentialsProvider, audioUri);
-        log.info("AWS Transcribe 작업 시작: {}", jobName);
-
-        // 변환된 텍스트 가져오기
-        String transcriptUri = awsTranscribe.getTranscriptionResult(credentialsProvider, jobName);
-
-        end = System.currentTimeMillis();
-        duration = end - start;
-        log.info("STT 소요 시간: {}ms", duration);
-
-        return awsTranscribe.parseTranscriptionJson(transcriptUri);
-    }
-
-    // 긴 비디오 처리 (4개로 분할 및 병렬 처리)
-    private String processLongVideoWithPresignedUrl(S3Client s3Client, Long videoId, String videoKey, double duration) {
-        try {
-            log.info("긴 영상 처리 시작: 비디오 ID {}, 길이 {} 초", videoId, duration);
-
-            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(videoKey)
-                    .build();
-            try (S3Presigner presigner = S3Presigner.builder()
-                    .region(Region.AP_NORTHEAST_2)
-                    .credentialsProvider(DefaultCredentialsProvider.create())
-                    .build()) {
-                PresignedGetObjectRequest presignedRequest = presigner.presignGetObject(r -> r
-                        .signatureDuration(Duration.ofMinutes(60))
-                        .getObjectRequest(getObjectRequest));
-                String presignedUrl = presignedRequest.url().toString();
-
-                List<String> transcripts = new ArrayList<>();
-                ExecutorService executor = Executors.newFixedThreadPool(4);
-                List<Future<String>> futures = new ArrayList<>();
-                double chunkDuration = duration / 4;
-
-                for (int i = 0; i < 4; i++) {
-                    final int chunkIndex = i;
-                    final double startTime = i * chunkDuration;
-                    final double chunkLength = chunkDuration;
-
-                    Future<String> future = executor.submit(() -> {
-                        Path tempChunk = Files.createTempFile("chunk-" + chunkIndex, ".webm");
-                        Path tempAudio = Files.createTempFile("audio-" + chunkIndex, ".mp3");
-
-                        try {
-                            ProcessBuilder pb = new ProcessBuilder(
-                                    "ffmpeg",
-                                    "-i", presignedUrl,
-                                    "-ss", String.format("%.2f", startTime),
-                                    "-t", String.format("%.2f", chunkLength),
-                                    "-c:v", "copy",
-                                    "-c:a", "copy",
-                                    tempChunk.toString()
-                            );
-                            pb.redirectErrorStream(true);
-                            Process process = pb.start();
-                            StringBuilder errorOutput = new StringBuilder();
-                            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
-                                String line;
-                                while ((line = reader.readLine()) != null) {
-                                    errorOutput.append(line).append("\n");
-                                }
-                            }
-                            process.waitFor(60, TimeUnit.SECONDS);
-
-                            ProcessBuilder audioPb = new ProcessBuilder(
-                                    "ffmpeg",
-                                    "-i", tempChunk.toString(),
-                                    "-vn",
-                                    "-acodec", "libmp3lame",
-                                    "-ar", "44100",
-                                    "-ac", "2",
-                                    "-f", "mp3",
-                                    tempAudio.toString()
-                            );
-                            audioPb.redirectErrorStream(true);
-                            Process audioProcess = audioPb.start();
-                            try (BufferedReader reader = new BufferedReader(new InputStreamReader(audioProcess.getErrorStream()))) {
-                                String line;
-                                while ((line = reader.readLine()) != null) {
-                                    errorOutput.append(line).append("\n");
-                                }
-                            }
-                            audioProcess.waitFor(60, TimeUnit.SECONDS);
-
-                            String audioFileName = "audio/chunk-" + chunkIndex + "-" + UUID.randomUUID() + ".mp3";
-                            PutObjectRequest putRequest = PutObjectRequest.builder()
-                                    .bucket(bucket)
-                                    .key(audioFileName)
-                                    .contentType("audio/mpeg")
-                                    .build();
-                            s3Client.putObject(putRequest, RequestBody.fromFile(tempAudio));
-                            String audioUri = "s3://" + bucket + "/" + audioFileName;
-
-                            String jobName = awsTranscribe.startTranscriptionJob(DefaultCredentialsProvider.create(), audioUri);
-                            String transcriptUri = awsTranscribe.getTranscriptionResult(DefaultCredentialsProvider.create(), jobName);
-                            String transcript = awsTranscribe.parseTranscriptionJson(transcriptUri);
-                            log.info("청크 {} 음성 변환 완료: {}", chunkIndex, transcript.length());
-
-                            return transcript;
-                        } finally {
-                            Files.deleteIfExists(tempChunk);
-                            Files.deleteIfExists(tempAudio);
-                        }
-                    });
-                    futures.add(future);
-                }
-
-                for (Future<String> future : futures) {
-                    try {
-                        String transcript = future.get();
-                        if (transcript != null && !transcript.trim().isEmpty()) {
-                            transcripts.add(transcript);
-                        }
-                    } catch (Exception e) {
-                        log.error("청크 처리 중 오류: {}", e.getMessage());
-                    }
-                }
-
-                executor.shutdown();
-                if (!executor.awaitTermination(60, TimeUnit.MINUTES)) {
-                    executor.shutdownNow();
-                }
-
-                String combinedAnswer = String.join(" ", transcripts);
-                log.info("긴 영상 텍스트 병합 완료: 길이 {}", combinedAnswer.length());
-                return combinedAnswer;
-            }
-        } catch (Exception e) {
-            log.error("긴 영상 처리 실패: 비디오 ID {}", videoId, e);
-            return "";
-        }
-    }
-
-    private String createThumbnailWithPresignedUrl(S3Client s3Client, String videoKey, String thumbnailKey) {
-        try {
-            log.info("썸네일 생성 시작: {}", thumbnailKey);
-
-            // presigned URL 생성
-            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(videoKey)
-                    .build();
-
-            try (S3Presigner presigner = S3Presigner.builder()
-                    .region(Region.AP_NORTHEAST_2)
-                    .credentialsProvider(DefaultCredentialsProvider.create())
-                    .build()) {
-
-                PresignedGetObjectRequest presignedRequest = presigner.presignGetObject(r -> r
-                        .signatureDuration(Duration.ofMinutes(10))
-                        .getObjectRequest(getObjectRequest));
-                String presignedUrl = presignedRequest.url().toString();
-
-                // 임시 썸네일 파일 생성
-                Path tempThumbnail = Files.createTempFile("thumb_", ".jpg");
-
-                // JavaCV를 사용해서 첫 프레임 추출
-                FFmpegFrameGrabber grabber = null;
-                try {
-                    grabber = new FFmpegFrameGrabber(presignedUrl);
-
-                    // 성능 최적화 옵션들
-                    grabber.setOption("threads", "auto");
-                    grabber.setOption("analyzeduration", "1000000"); // 1초
-                    grabber.setOption("probesize", "1000000"); // 1MB
-
-                    grabber.start();
-
-                    // 비디오 정보 로깅
-                    log.debug("비디오 정보 - 길이: {}초, 해상도: {}x{}, FPS: {}",
-                            grabber.getLengthInTime() / 1000000.0,
-                            grabber.getImageWidth(),
-                            grabber.getImageHeight(),
-                            grabber.getVideoFrameRate());
-
-                    // 첫 프레임으로 이동 (시간 기준: 마이크로초)
-                    grabber.setTimestamp(1000); // 0.001초 위치
-
-                    // 프레임 추출
-                    Frame frame = grabber.grabImage();
-                    if (frame == null) {
-                        // 첫 프레임이 null일 경우 다음 프레임 시도
-                        log.debug("첫 프레임이 null, 다음 프레임 시도");
-                        frame = grabber.grabImage();
-                    }
-
-                    if (frame == null) {
-                        log.error("비디오에서 프레임을 추출할 수 없습니다: {}", videoKey);
-                        return DEFAULT_THUMBNAIL_URL;
-                    }
-
-                    // Frame을 BufferedImage로 변환
-                    Java2DFrameConverter converter = new Java2DFrameConverter();
-                    BufferedImage image = converter.convert(frame);
-
-                    if (image == null) {
-                        log.error("프레임을 이미지로 변환할 수 없습니다");
-                        return DEFAULT_THUMBNAIL_URL;
-                    }
-
-                    // 썸네일 크기 조정 (옵션)
-                    BufferedImage thumbnail = resizeImage(image, 800, 600);
-
-                    // JPEG로 저장 (품질 설정)
-                    saveAsJpeg(thumbnail, tempThumbnail.toFile(), 0.85f);
-
-                    log.info("썸네일 생성 완료: {} bytes", Files.size(tempThumbnail));
-
-                } finally {
-                    // 리소스 해제
-                    if (grabber != null) {
-                        try {
-                            grabber.stop();
-                            grabber.release();
-                        } catch (Exception e) {
-                            log.warn("FFmpegFrameGrabber 해제 실패: {}", e.getMessage());
-                        }
-                    }
-                }
-
-                // 생성된 썸네일 파일 검증
-                if (!Files.exists(tempThumbnail) || Files.size(tempThumbnail) == 0) {
-                    log.error("썸네일 파일이 생성되지 않았습니다.");
-                    return DEFAULT_THUMBNAIL_URL;
-                }
-
-                // S3에 썸네일 업로드
-                PutObjectRequest putRequest = PutObjectRequest.builder()
-                        .bucket(bucket)
-                        .key(thumbnailKey)
-                        .contentType("image/jpeg")
-                        .acl(ObjectCannedACL.PUBLIC_READ)
-                        .build();
-
-                s3Client.putObject(putRequest, RequestBody.fromFile(tempThumbnail));
-
-                // 임시 파일 삭제
-                Files.delete(tempThumbnail);
-
-                String url = String.format("%s/%s", getS3UrlPrefix(), thumbnailKey);
-                log.info("썸네일 업로드 완료");
-                return url;
-            }
-
-        } catch (Exception e) {
-            log.warn("썸네일 생성 실패: {}", e.getMessage(), e);
-            return DEFAULT_THUMBNAIL_URL;
-        }
-    }
-
-    private String createThumbnail(byte[] videoBytes, String thumbnailKey, S3Client s3Client) {
-        FFmpegFrameGrabber grabber = null;
-        try {
-            log.info("썸네일 생성 시작: {}", thumbnailKey);
-
-            if (videoBytes.length == 0) {
-                log.warn("비디오 데이터가 비어있음. Returning default thumbnail.");
-                return DEFAULT_THUMBNAIL_URL;
-            }
-
-            // FFmpeg 프로세스 빌더 생성 - 첫 프레임을 추출
-            ProcessBuilder pb = new ProcessBuilder(
-                    "ffmpeg",
-                    "-i", "pipe:0",           // 입력은 stdin에서
-                    "-ss", "00:00:00.001",    // 시작 직후 (1ms)
-                    "-vframes", "1",          // 1개 프레임만 추출
-                    "-q:v", "2",              // 품질 설정 (낮을수록 좋은 품질)
-                    "-f", "image2",           // 이미지 출력 형식
-                    "-c:v", "mjpeg",          // JPEG 인코더
-                    "pipe:1"                  // stdout으로 출력
-            );
-
-            Process process = pb.start();
-
-            // FFmpeg에 비디오 데이터 전송하는 스레드
-            Thread inputThread = new Thread(() -> {
-                try (OutputStream ffmpegInput = process.getOutputStream()) {
-                    ffmpegInput.write(videoBytes);
-                    ffmpegInput.flush();
-                } catch (IOException e) {
-                    log.error("FFmpeg에 비디오 데이터 전송 중 오류", e);
-                }
-            });
-            inputThread.start();
-
-            // FFmpeg 에러 출력 로깅하는 스레드
-            StringBuilder errorOutput = new StringBuilder();
-            Thread errorThread = new Thread(() -> {
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        errorOutput.append(line).append("\n");
-                    }
-                } catch (IOException e) {
-                    log.error("FFmpeg 오류 스트림 읽기 실패", e);
-                }
-            });
-            errorThread.start();
-
-            // FFmpeg 표준 출력에서 이미지 읽기
-            byte[] thumbnailBytes;
-            try (InputStream ffmpegOutput = process.getInputStream()) {
-                thumbnailBytes = IOUtils.toByteArray(ffmpegOutput);
-            }
-
-            // 스레드 완료 대기
-            inputThread.join();
-            errorThread.join();
-
-            // 프로세스 완료 대기
-            boolean completed = process.waitFor(30, TimeUnit.SECONDS);
-            if (!completed) {
-                process.destroyForcibly();
-                log.error("FFmpeg 처리 타임아웃");
-                return DEFAULT_THUMBNAIL_URL;
-            }
-
-            int exitCode = process.exitValue();
-            if (exitCode != 0 || thumbnailBytes.length == 0) {
-                log.error("FFmpeg 썸네일 생성 실패. 종료 코드: {}, 에러: {}", exitCode, errorOutput);
-                return DEFAULT_THUMBNAIL_URL;
-            }
-
-            log.info("FFmpeg 썸네일 생성 성공. 크기: {} bytes", thumbnailBytes.length);
-
-            // S3에 업로드
-            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(thumbnailKey)
-                    .acl(ObjectCannedACL.PUBLIC_READ)  // PublicRead 설정
-                    .build();
-
-            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(
-                    new ByteArrayInputStream(thumbnailBytes),
-                    thumbnailBytes.length));
-            log.info("썸네일 S3 업로드 완료: {}", thumbnailKey);
-            String url = String.format("%s/%s", getS3UrlPrefix(), thumbnailKey);
-            return url;
-        } catch (Exception e) {
-            log.warn("썸네일 생성 중 예외 발생. 기본 썸네일 반환", e);
-            return DEFAULT_THUMBNAIL_URL;
-        }
-    }
-
-    /**
-     * 이미지 크기 조정 (비율 유지)
-     */
-    private BufferedImage resizeImage(BufferedImage original, int maxWidth, int maxHeight) {
-        int originalWidth = original.getWidth();
-        int originalHeight = original.getHeight();
-
-        // 비율 계산
-        double scaleX = (double) maxWidth / originalWidth;
-        double scaleY = (double) maxHeight / originalHeight;
-        double scale = Math.min(scaleX, scaleY);
-
-        // 원본이 이미 작다면 그대로 반환
-        if (scale >= 1.0) {
-            return original;
-        }
-
-        int newWidth = (int) (originalWidth * scale);
-        int newHeight = (int) (originalHeight * scale);
-
-        BufferedImage resized = new BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_RGB);
-        Graphics2D g2d = resized.createGraphics();
-
-        // 고품질 렌더링 설정
-        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-        g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
-        g2d.drawImage(original, 0, 0, newWidth, newHeight, null);
-        g2d.dispose();
-
-        return resized;
-    }
-
-    /**
-     * JPEG 품질 설정하여 저장
-     */
-    private void saveAsJpeg(BufferedImage image, File outputFile, float quality) throws IOException {
-        Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("jpeg");
-        if (!writers.hasNext()) {
-            throw new IllegalStateException("JPEG writer를 찾을 수 없습니다");
-        }
-
-        ImageWriter writer = writers.next();
-        ImageWriteParam param = writer.getDefaultWriteParam();
-
-        if (param.canWriteCompressed()) {
-            param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
-            param.setCompressionQuality(quality);
-        }
-
-        try (FileImageOutputStream output = new FileImageOutputStream(outputFile)) {
-            writer.setOutput(output);
-            writer.write(null, new IIOImage(image, null, null), param);
-        } finally {
-            writer.dispose();
-        }
+    public CompletableFuture<Void> createInitial(
+            String username, Long questionId, int requestNo,
+            String videoKey, Boolean isOpen, long startTime) {
+        return videoProcessingService.createInitial(username, questionId, requestNo, videoKey, isOpen, startTime);
     }
 
     public VideoWithFeedbackDTO getVideoWithFeedback(Long videoId) {
         Video video = videoRepository.findById(videoId)
                 .orElseThrow(QuestionNotFoundException::new);
-        return returnVideoWithFeedback(video);
+        return toVideoWithFeedback(video);
     }
 
     public List<VideoReturnDTO> getOpenVideos() {
@@ -877,42 +88,6 @@ public class VideoService {
         videoRepository.delete(video);
     }
 
-    private VideoWithFeedbackDTO returnVideoWithFeedback(Video video) {
-        VideoReturnDTO videoReturnDTO = VideoReturnDTO.from(video);
-        if (video.getFeedback() == null) {
-            return VideoWithFeedbackDTO.builder().video(videoReturnDTO).feedback(null).build();
-        }
-        Feedback feedback = feedbackService.findFeedback(video.getFeedback().getId());
-        return VideoWithFeedbackDTO.builder()
-                .video(videoReturnDTO)
-                .feedback(FeedbackReturnDTO.from(feedback))
-                .build();
-    }
-
-    public boolean checkThreadPoolCapacity() {
-        ThreadPoolExecutor executor = videoProcessingExecutor.getThreadPoolExecutor();
-
-        int activeCount = executor.getActiveCount();
-        int queueSize = executor.getQueue().size();
-        int totalLoad = activeCount + queueSize;
-        int maxCapacity = CORE_POOL_SIZE + QUEUE_CAPACITY;
-
-        double loadRatio = (double) totalLoad / maxCapacity;
-
-        log.info("스레드풀 상태 - Active: {}, Queue: {}, Total: {}/{} ({:.1f}%)",
-                activeCount, queueSize, totalLoad, maxCapacity, loadRatio * 100);
-
-        // 실험: 48/60 (80%) 미만일 때만 즉시 처리
-        boolean hasCapacity = loadRatio < CAPACITY_THRESHOLD;
-
-        if (!hasCapacity) {
-            log.warn("스레드풀 용량 부족: {}/{} (임계값: {}%)",
-                    totalLoad, maxCapacity, (int)(CAPACITY_THRESHOLD * 100));
-        }
-
-        return hasCapacity;
-    }
-
     @Transactional
     public Long enqueue(String username, Long questionId, int requestNo, String videoKey, Boolean isOpen, long startTime) {
         VideoProcessingQueue request = VideoProcessingQueue.builder()
@@ -924,13 +99,34 @@ public class VideoService {
                 .startTime(startTime)
                 .usePresignedUrl(true)
                 .build();
-
-        VideoProcessingQueue savedRequest = queueRepository.save(request);
-
-        log.info("DB 큐 저장 완료: queueId={}, videoKey={}, 현재 대기: {}개",
-                savedRequest.getId(), videoKey, queueRepository.countPendingTasks());
-
-        return savedRequest.getId();
+        VideoProcessingQueue saved = queueRepository.save(request);
+        log.info("DB 큐 저장 완료: queueId={}, videoKey={}, 대기: {}개",
+                saved.getId(), videoKey, queueRepository.countPendingTasks());
+        return saved.getId();
     }
 
+    public boolean checkThreadPoolCapacity() {
+        ThreadPoolExecutor executor = videoProcessingExecutor.getThreadPoolExecutor();
+        int totalLoad = executor.getActiveCount() + executor.getQueue().size();
+        int maxCapacity = CORE_POOL_SIZE + QUEUE_CAPACITY;
+        double loadRatio = (double) totalLoad / maxCapacity;
+        boolean hasCapacity = loadRatio < CAPACITY_THRESHOLD;
+        if (!hasCapacity) {
+            log.warn("스레드풀 용량 부족: {}/{} (임계값: {}%)",
+                    totalLoad, maxCapacity, (int) (CAPACITY_THRESHOLD * 100));
+        }
+        return hasCapacity;
+    }
+
+    private VideoWithFeedbackDTO toVideoWithFeedback(Video video) {
+        VideoReturnDTO videoDTO = VideoReturnDTO.from(video);
+        if (video.getFeedback() == null) {
+            return VideoWithFeedbackDTO.builder().video(videoDTO).feedback(null).build();
+        }
+        Feedback feedback = feedbackService.findFeedback(video.getFeedback().getId());
+        return VideoWithFeedbackDTO.builder()
+                .video(videoDTO)
+                .feedback(FeedbackReturnDTO.from(feedback))
+                .build();
+    }
 }

--- a/src/main/java/com/site/xidong/global/exception/ErrorCode.java
+++ b/src/main/java/com/site/xidong/global/exception/ErrorCode.java
@@ -32,6 +32,9 @@ public enum ErrorCode {
     DUPLICATE_RESOURCE(409, "데이터가 이미 존재합니다"),
     EMAIL_ALREADY_EXISTS(409, "이미 사용 중인 이메일입니다"),
     // 500
+    STT_TIMEOUT(500, "음성 변환 시간이 초과되었습니다"),
+    STT_FAILED(500, "음성 변환에 실패했습니다"),
+    AI_API_ERROR(500, "AI 피드백 생성에 실패했습니다"),
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다");
 
     private final int status;


### PR DESCRIPTION
 - VideoService God Class(936줄)를 3개 서비스로 분리
    - ThumbnailService — FFmpeg 첫 프레임 추출 및 S3 업로드 전담
    - SttService — 영상 길이 추정, Whisper/AWS Transcribe 오케스트레이션 전담
    - VideoProcessingService — @Async 파이프라인 전담, self-injection(@Lazy) 제거
  - AwsTranscribe — static → 인스턴스 메서드, 인증 파라미터 제거, 폴링 타임아웃 적용
  - FeedbackService — ClaudeApiClient 분리로 HTTP 책임 제거
  - ClaudeApiClient — Claude API 호출 캡슐화 (신규)
  - AwsV2Config — S3Client / TranscribeClient Spring Bean 등록 (신규)
  - VideoQueueProcessor — 스케줄러의 this.processTask() 호출로 인한 @Transactional 프록시 우회 버그 수정 (신규)
  - VideoQueueScheduler — this.processTask() → processor.processTask() 호출, 로그 포맷 버그 수정 ("작업 시작: " → "작업 시작: {}")
  - ErrorCode — STT_TIMEOUT, STT_FAILED, AI_API_ERROR 추가